### PR TITLE
feat(helpers): add name property for output object

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -329,6 +329,8 @@ module.exports = {
     }
 
     item.request = request;
+    // add name property, which postman will use to show in UI
+    item.name = request && request.url && request.url.path && request.url.path.join('/');
 
     return item;
   },


### PR DESCRIPTION
this change adds name of item to output json, as result postman will show user friendly name in it's interface instead of just showing empty place