### PR TITLE
Fixed issue where module threw exception when anchors are used in YAML document.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -54,6 +54,7 @@ Converter = {
       return Swagger2OpenAPI.convertObj(parseResult.swagger, {
         fatal: false,
         patch: true,
+        anchors: true,
         warnOnly: true
       }, function(err, oas3Wrapper) {
         if (err) {

--- a/test/data/valid_swagger_yaml/yaml_anchor.yaml
+++ b/test/data/valid_swagger_yaml/yaml_anchor.yaml
@@ -1,0 +1,67 @@
+swagger: '2.0'
+info:
+  title: YAML anchor issue
+  version: '1.0'
+schemes:
+  - https
+securityDefinitions:
+  Bearer:
+    description: Authorization 'Bearer' token
+    in: header
+    name: Authorization
+    type: apiKey
+tags:
+  - name: client
+    description: Client resources
+paths:
+  /client:
+    get:
+      deprecated: false
+      summary: Query Client
+      produces: &ref_0
+        - application/json
+      security: &ref_1
+        - Bearer: []
+      tags: &ref_2
+        - client
+      parameters:
+        - &ref_5
+          in: query
+          name: page
+          type: integer
+        - &ref_6
+          in: query
+          name: pageSize
+          type: integer
+          default: 25
+      responses:
+        '200':
+          description: Search results
+          schema:
+            properties:
+              pagination: &ref_7
+                type: object
+                properties:
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+                  total:
+                    type: integer
+                  count:
+                    type: integer
+            type: object
+    post:
+      deprecated: false
+      summary: Create a new Client
+      produces: *ref_0
+      security: *ref_1
+      tags: *ref_2
+      responses:
+        '201': &ref_9
+          description: Created
+          schema:
+            type: object
+            properties:
+              _id:
+                type: string

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -3,6 +3,7 @@ var expect = require('chai').expect,
   fs = require('fs'),
   path = require('path'),
   VALID_SWAGGER_PATH = '../data/valid_swagger',
+  VALID_SWAGGER_YAML_PATH = '../data/valid_swagger_yaml',
   INVALID_SWAGGER_PATH = '../data/invalid_swagger';
 
 /* global describe, it */
@@ -66,6 +67,22 @@ describe('The converter must convert a swagger string', function() {
     var sampleString = fs.readFileSync(path.join(__dirname, VALID_SWAGGER_PATH, 'sampleswagger.json'), 'utf8');
 
     Converter.convert({ type: 'string', data: sampleString }, {}, (err, result) => {
+      expect(result.result).to.equal(true);
+      expect(result.output.length).to.equal(1);
+      expect(result.output[0].type).to.have.equal('collection');
+      expect(result.output[0].data).to.have.property('info');
+      expect(result.output[0].data).to.have.property('item');
+    });
+    done();
+  });
+});
+
+describe('The converter must convert a swagger document with YAML anchors', function() {
+  it('yaml_anchor.yaml', function(done) {
+    var sampleYaml = fs.readFileSync(path.join(__dirname, VALID_SWAGGER_YAML_PATH, 'yaml_anchor.yaml'), 'utf8');
+
+    Converter.convert({ type: 'string', data: sampleYaml }, {}, (err, result) => {
+      expect(err).to.be.null;
       expect(result.result).to.equal(true);
       expect(result.output.length).to.equal(1);
       expect(result.output[0].type).to.have.equal('collection');


### PR DESCRIPTION
## RCA:

We use swagger2openapi module to first convert Swagger 2.0 document to OpenAPI v3 and then use OpenAPI-to-Postman module for conversion.

In this flow, when there are YAML anchors used in Swagger document. swagger2openapi module throws the following exception for the attached file in issue.

```
S2OError: YAML anchor or merge key at #/paths/~1client/post/produces
    at throwError (/Users/vishal/swagger2-postman2/node_modules/swagger2openapi/index.js:39:15)
    at /Users/vishal/swagger2-postman2/node_modules/swagger2openapi/index.js:1369:21
    at recurse (/Users/vishal/swagger2-postman2/node_modules/reftools/lib/recurse.js:38:13)
    at recurse (/Users/vishal/swagger2-postman2/node_modules/reftools/lib/recurse.js:53:13)
    at recurse (/Users/vishal/swagger2-postman2/node_modules/reftools/lib/recurse.js:53:13)
    at recurse (/Users/vishal/swagger2-postman2/node_modules/reftools/lib/recurse.js:53:13)
```

## Fix:

Upon deep dive into swagger2openapi module, we found that we have to specifically specify option to enable anchor cloning while using API provided by module. Here is reference.

Enabling this option solves the corresponding issue.

